### PR TITLE
Add tests to virtual file manager.

### DIFF
--- a/src/core/file_storage/virtual_file_manager.go
+++ b/src/core/file_storage/virtual_file_manager.go
@@ -8,11 +8,22 @@ import (
 	"github.com/google/uuid"
 )
 
+var ErrParentDirDNE = fmt.Errorf("Parent directory does not exist")
+
 type VirtualDirectory struct {
 	Name    string
 	Id      uuid.UUID
 	Subdirs map[uuid.UUID]bool
 	Files   map[uuid.UUID]bool
+}
+
+func makeVirtualDirectory(name string, id uuid.UUID) *VirtualDirectory {
+	return &VirtualDirectory{
+		Name:    name,
+		Id:      id,
+		Subdirs: make(map[uuid.UUID]bool),
+		Files:   make(map[uuid.UUID]bool),
+	}
 }
 
 type VirtualFile struct {
@@ -28,6 +39,26 @@ type VirtualFileManager struct {
 	RWLock sync.RWMutex
 }
 
+func NewVirtualFileManager() *VirtualFileManager {
+	return &VirtualFileManager{
+		Directories: make(map[uuid.UUID]VirtualDirectory),
+		Files:       make(map[uuid.UUID]VirtualFile),
+	}
+}
+
+func (m *VirtualFileManager) CreateNewNamespace(name string) (uuid.UUID, error) {
+	ns_id, err := uuid.NewUUID()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("Failed to construct new UUID for new namespace: %v", err)
+	}
+
+	m.RWLock.Lock()
+	defer m.RWLock.Unlock()
+	m.Directories[ns_id] = *makeVirtualDirectory(name, ns_id)
+
+	return ns_id, nil
+}
+
 func (m *VirtualFileManager) CreateNewFile(filename string, parent uuid.UUID) (uuid.UUID, error) {
 	fileUUID, err := uuid.NewUUID()
 	if err != nil {
@@ -35,7 +66,12 @@ func (m *VirtualFileManager) CreateNewFile(filename string, parent uuid.UUID) (u
 	}
 
 	m.RWLock.Lock()
-	m.Directories[parent].Files[fileUUID] = true
+	dir, exists := m.Directories[parent]
+	if !exists {
+		return uuid.Nil, ErrParentDirDNE
+	}
+
+	dir.Files[fileUUID] = true
 	m.Files[fileUUID] = VirtualFile{Name: filename, Id: fileUUID}
 	m.RWLock.Unlock()
 
@@ -49,12 +85,13 @@ func (m *VirtualFileManager) CreateNewDirectory(dirname string, parent uuid.UUID
 	}
 
 	m.RWLock.Lock()
-	m.Directories[parent].Files[dirUUID] = true
-	m.Directories[dirUUID] = VirtualDirectory{
-		Name:    dirname,
-		Id:      dirUUID,
-		Subdirs: make(map[uuid.UUID]bool),
-		Files:   make(map[uuid.UUID]bool)}
+	dir, exists := m.Directories[parent]
+	if !exists {
+		return uuid.Nil, ErrParentDirDNE
+	}
+
+	dir.Files[dirUUID] = true
+	m.Directories[dirUUID] = *makeVirtualDirectory(dirname, dirUUID)
 	m.RWLock.Unlock()
 
 	return dirUUID, nil

--- a/src/core/file_storage/virtual_file_manager_test.go
+++ b/src/core/file_storage/virtual_file_manager_test.go
@@ -1,0 +1,149 @@
+package hootfs
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestCreateNewNamespaceWorks(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	ns_id, err := vfm.CreateNewNamespace("namespace")
+	if err != nil {
+		t.Errorf("Failed to create new namespace: %v", err)
+	}
+
+	_, exists := vfm.Directories[ns_id]
+	if !exists {
+		t.Errorf("No namespace root directory added to virtual file system")
+	}
+}
+
+func TestCreateNewFileWorks(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	ns_id, err := vfm.CreateNewNamespace("ns")
+	if err != nil {
+		t.Fatalf("Failed to create new namespace: %v", err)
+	}
+
+	file_id, err := vfm.CreateNewFile("filename", ns_id)
+	if err != nil {
+		t.Errorf("Failed to create new file: %v", err)
+	}
+	virfile, exists := vfm.Files[file_id]
+	if !exists {
+		t.Errorf("Created file does not exist in the virtual file manager.")
+	}
+
+	if virfile.Id != file_id || virfile.Name != "filename" {
+		t.Errorf("File fields do not match.")
+	}
+}
+
+func TestCreateNewFileFailsIfParentDirectoryD(t *testing.T) {
+	vfm := NewVirtualFileManager()
+
+	if _, err := vfm.CreateNewFile("filename", uuid.Nil); err != ErrParentDirDNE {
+		t.Errorf("Expected to get '%v', got '%v'", ErrParentDirDNE, err)
+	}
+
+}
+
+func TestCreateNewDirectoryWorks(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	ns_id, err := vfm.CreateNewNamespace("ns")
+	if err != nil {
+		t.Fatalf("Failed to create new namespace: %v", err)
+	}
+
+	dir_id, err := vfm.CreateNewDirectory("dirname", ns_id)
+	if err != nil {
+		t.Errorf("Failed to create new directory: %v", err)
+	}
+	virdir, exists := vfm.Directories[dir_id]
+	if !exists {
+		t.Errorf("Created file does not exist in the virtual file manager.")
+	}
+
+	if virdir.Id != dir_id || virdir.Name != "dirname" {
+		t.Errorf("File fields do not match.")
+	}
+}
+
+func TestCreateNewDirectoryFailsIfParentDirectoryDne(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	if _, err := vfm.CreateNewDirectory("dirname", uuid.Nil); err != ErrParentDirDNE {
+		t.Errorf("Expected to get '%v', got '%v'", ErrParentDirDNE, err)
+	}
+}
+
+func TestAddNewFileWorks(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	ns_id, err := vfm.CreateNewNamespace("ns")
+	if err != nil {
+		t.Fatalf("Failed to create new namespace: %v", err)
+	}
+
+	file_id := uuid.MustParse(strings.Repeat("1", 32))
+
+	vf := VirtualFile{Name: "filename", Id: file_id}
+	if err := vfm.AddNewFile(&vf, ns_id); err != nil {
+		t.Errorf("Error adding new file to virtual filesystem: %v", err)
+	}
+
+	if vfm.Files[file_id] != vf {
+		t.Errorf("File in Virtual File Manager does not match added file.")
+	}
+
+	if val, exists := vfm.Directories[ns_id].Files[file_id]; exists == false || val != true {
+		t.Errorf("File does not exist in parent directory.")
+	}
+}
+
+func TestAddNewFileFailsIfParentDirDNE(t *testing.T) {
+	vfm := NewVirtualFileManager()
+
+	file_id := uuid.MustParse(strings.Repeat("1", 32))
+
+	vf := VirtualFile{Name: "filename", Id: file_id}
+	if err := vfm.AddNewFile(&vf, uuid.Nil); errors.Is(err, ErrDirNotFound(uuid.Nil)) {
+		t.Errorf("Expected error %v, got error %v instead", ErrDirNotFound(uuid.Nil), err)
+	}
+}
+
+func TestAddNewDirectoryWorks(t *testing.T) {
+	vfm := NewVirtualFileManager()
+	ns_id, err := vfm.CreateNewNamespace("ns")
+	if err != nil {
+		t.Fatalf("Failed to create new namespace: %v", err)
+	}
+
+	dir_id := uuid.MustParse(strings.Repeat("1", 32))
+
+	vd := makeVirtualDirectory("dirname", dir_id)
+	if err := vfm.AddNewDirectory(vd, ns_id); err != nil {
+		t.Errorf("Error adding new file to virtual filesystem: %v", err)
+	}
+
+	if !reflect.DeepEqual(vfm.Directories[dir_id], *vd) {
+		t.Errorf("File in Virtual File Manager does not match added file.")
+	}
+
+	if val, exists := vfm.Directories[ns_id].Subdirs[dir_id]; exists == false || val != true {
+		t.Errorf("File does not exist in parent directory.")
+	}
+}
+
+func TestAddNewDirectoryFailsIfParentDirDNE(t *testing.T) {
+	vfm := NewVirtualFileManager()
+
+	dir_id := uuid.MustParse(strings.Repeat("1", 32))
+
+	vd := makeVirtualDirectory("dir", dir_id)
+	if err := vfm.AddNewDirectory(vd, uuid.Nil); errors.Is(err, ErrDirNotFound(uuid.Nil)) {
+		t.Errorf("Expected error %v, got error %v instead", ErrDirNotFound(uuid.Nil), err)
+	}
+}

--- a/src/core/hootfs_main.go
+++ b/src/core/hootfs_main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 
-	"github.com/google/uuid"
 	hootfs "github.com/hootfs/hootfs/src/core/file_storage"
 	core "github.com/hootfs/hootfs/src/core/hootfs"
 )
@@ -20,10 +19,7 @@ func main() {
 	server := core.NewHootFsServer(
 		discover_hostname,
 		hootfs.NewFileSystemManager(hootfs_root),
-		&hootfs.VirtualFileManager{
-			Directories: make(map[uuid.UUID]hootfs.VirtualDirectory),
-			Files:       make(map[uuid.UUID]hootfs.VirtualFile),
-		})
+		hootfs.NewVirtualFileManager())
 	if err := server.StartServer(); err != nil {
 		log.Fatalf("Server initialization failed: %v", err)
 	}


### PR DESCRIPTION
As the description says, this pull request adds a number of tests to the virtual file manager. The move and remove methods are left untested until those features are fleshed out E2E.

This PR also slightly updates the code of the virtual file manager to be safer against non-existent UUIDs (see #21).