### PR TITLE
Update Services to return empty response in case of error.

### DIFF
--- a/src/core/cluster/cluster_service.go
+++ b/src/core/cluster/cluster_service.go
@@ -117,11 +117,11 @@ func (c *ClusterServer) UpdateFileContentsCS(ctx context.Context,
 	request *hootpb.UpdateFileContentsCSRequest) (*hootpb.UpdateFileContentsCSResponse, error) {
 	file_id, err := uuid.FromBytes(request.FileId.Value)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
+		return &hootpb.UpdateFileContentsCSResponse{}, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 	file_info := hootfs.FileInfo{NamespaceId: request.UserId, ObjectId: file_id}
 	if err := c.fmg.WriteFile(&file_info, request.Contents); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Unable to write file %v: %v", file_info.ObjectId, err))
+		return &hootpb.UpdateFileContentsCSResponse{}, status.Error(codes.Internal, fmt.Sprintf("Unable to write file %v: %v", file_info.ObjectId, err))
 	}
 	return &hootpb.UpdateFileContentsCSResponse{
 		UpdatedFileId: &hootpb.UUID{Value: file_id[:]}}, nil
@@ -130,16 +130,16 @@ func (c *ClusterServer) UpdateFileContentsCS(ctx context.Context,
 func (c *ClusterServer) MoveObjectCS(ctx context.Context, request *hootpb.MoveObjectCSRequest) (*hootpb.MoveObjectCSResponse, error) {
 	obj_id, err := uuid.FromBytes(request.CurrObjectId.Value)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
+		return &hootpb.MoveObjectCSResponse{}, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 
 	if _, exists := c.vfmg.Directories[obj_id]; exists {
 
 	}
 
-	return nil, ErrUnimplemented
+	return &hootpb.MoveObjectCSResponse{}, status.Error(codes.Unimplemented, ErrUnimplemented.Error())
 }
 
 func (c *ClusterServer) RemoveObjectCS(ctx context.Context, request *hootpb.RemoveObjectCSRequest) (*hootpb.RemoveObjectCSResponse, error) {
-	return nil, ErrUnimplemented
+	return &hootpb.RemoveObjectCSResponse{}, status.Error(codes.Unimplemented, ErrUnimplemented.Error())
 }

--- a/src/core/cluster/cluster_service.go
+++ b/src/core/cluster/cluster_service.go
@@ -65,11 +65,11 @@ func (c *ClusterServer) AddNewFileCS(ctx context.Context,
 	request *hootpb.AddNewFileCSRequest) (*hootpb.AddNewFileCSResponse, error) {
 	new_id, err := uuid.FromBytes(request.NewFileId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return &hootpb.AddNewFileCSResponse{}, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 	par_id, err := uuid.FromBytes(request.ParentDirId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return &hootpb.AddNewFileCSResponse{}, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 
 	// Add new file to virtual file manager
@@ -82,7 +82,7 @@ func (c *ClusterServer) AddNewFileCS(ctx context.Context,
 	new_file_info := hootfs.FileInfo{NamespaceId: request.UserId, ObjectId: new_id}
 	c.fmg.CreateFile(request.NewFileName, &new_file_info)
 	if err := c.fmg.WriteFile(&new_file_info, request.Contents); err != nil {
-		return nil, status.Error(
+		return &hootpb.AddNewFileCSResponse{}, status.Error(
 			codes.Internal, fmt.Sprintf("Failed to write  to file: %v", err))
 	}
 
@@ -93,11 +93,13 @@ func (c *ClusterServer) MakeDirectoryCS(ctx context.Context,
 	request *hootpb.MakeDirectoryCSRequest) (*hootpb.MakeDirectoryCSResponse, error) {
 	dir_id, err := uuid.FromBytes(request.NewDirId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return &hootpb.MakeDirectoryCSResponse{},
+			status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 	par_id, err := uuid.FromBytes(request.ParentDirId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return &hootpb.MakeDirectoryCSResponse{},
+			status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 	vir_dir := hootfs.VirtualDirectory{
 		Name:    request.NewDirName,
@@ -115,7 +117,7 @@ func (c *ClusterServer) UpdateFileContentsCS(ctx context.Context,
 	request *hootpb.UpdateFileContentsCSRequest) (*hootpb.UpdateFileContentsCSResponse, error) {
 	file_id, err := uuid.FromBytes(request.FileId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return nil, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 	file_info := hootfs.FileInfo{NamespaceId: request.UserId, ObjectId: file_id}
 	if err := c.fmg.WriteFile(&file_info, request.Contents); err != nil {
@@ -128,7 +130,7 @@ func (c *ClusterServer) UpdateFileContentsCS(ctx context.Context,
 func (c *ClusterServer) MoveObjectCS(ctx context.Context, request *hootpb.MoveObjectCSRequest) (*hootpb.MoveObjectCSResponse, error) {
 	obj_id, err := uuid.FromBytes(request.CurrObjectId.Value)
 	if err != nil {
-		return nil, ErrInvalidId
+		return nil, status.Error(codes.InvalidArgument, ErrInvalidId.Error())
 	}
 
 	if _, exists := c.vfmg.Directories[obj_id]; exists {

--- a/src/core/file_storage/virtual_file_manager.go
+++ b/src/core/file_storage/virtual_file_manager.go
@@ -85,6 +85,7 @@ func (m *VirtualFileManager) CreateNewDirectory(dirname string, parent uuid.UUID
 	}
 
 	m.RWLock.Lock()
+	defer m.RWLock.Unlock()
 	dir, exists := m.Directories[parent]
 	if !exists {
 		return uuid.Nil, ErrParentDirDNE
@@ -92,7 +93,6 @@ func (m *VirtualFileManager) CreateNewDirectory(dirname string, parent uuid.UUID
 
 	dir.Files[dirUUID] = true
 	m.Directories[dirUUID] = *makeVirtualDirectory(dirname, dirUUID)
-	m.RWLock.Unlock()
 
 	return dirUUID, nil
 }

--- a/src/core/hootfs/head_node.go
+++ b/src/core/hootfs/head_node.go
@@ -159,13 +159,13 @@ func (s *HootFsServer) MakeDirectory(
 	parentUuid, err := uuid.FromBytes(request.DirId.Value)
 
 	if err != nil {
-		return nil, err
+		return &head.MakeDirectoryResponse{}, status.Error(codes.Internal, "Error creating error.")
 	}
 
 	dirUuid, err := s.vfmg.CreateNewDirectory(request.DirName, parentUuid)
-
 	if err != nil {
-		return nil, err
+		return &head.MakeDirectoryResponse{},
+			status.Error(codes.Internal, fmt.Sprintf("Failed to create directory: %v", err))
 	}
 
 	// Broadcast directory creation to all other clients.


### PR DESCRIPTION
Originally, when there was an internal error on the server, the default behavior would be to send back a nil response and an error. However, this behavior is not correct. Instead, we should send back an empty response.

This PR also addresses #21, where only a single response would be returned for a `CreateDirectory` request. The issue stemmed from the fact that a lock on an internal data structure was not being released before a method returned.